### PR TITLE
fix: resolve all compiler warnings

### DIFF
--- a/src/monad_laws_wbtest.mbt
+++ b/src/monad_laws_wbtest.mbt
@@ -17,16 +17,16 @@ fn[S, V, W, X] bind_associator(
   f : (V) -> State[S, W],
   g : (W) -> State[S, X],
 ) -> (State[S, X], State[S, X]) {
-  (m.bind(f).bind(g), m.bind(fn { x => f(x).bind(g) }))
+  (m.bind(f).bind(g), m.bind(fn(x) { f(x).bind(g) }))
 }
 
 ///|
-fn[S : Eq + Show, V : Eq + Show] run_state_eq(
+fn[S : Eq, V : Eq] run_state_eq(
   m : (State[S, V], State[S, V]),
   state : S,
 ) -> Bool {
-  let (v1, s1) = run_state(m.0, state)
-  let (v2, s2) = run_state(m.1, state)
+  let (v1, s1) = m.0.run_state(state)
+  let (v2, s2) = m.1.run_state(state)
   v1 == v2 && s1 == s2
 }
 
@@ -34,11 +34,11 @@ fn[S : Eq + Show, V : Eq + Show] run_state_eq(
 test "state_monad_laws" {
   let counter = State::new(10)
   fn add(s) -> State[Int, Int] {
-    put(s + 2).bind(fn { _ => get() })
+    put(s + 2).bind(fn(_) { get() })
   }
 
   fn mul(s) -> State[Int, Int] {
-    put(s * 2).bind(fn { _ => get() })
+    put(s * 2).bind(fn(_) { get() })
   }
 
   let m1 = left_identity(10, add)
@@ -51,7 +51,7 @@ test "state_monad_laws" {
 
 ///|
 fn[S, V] map_identity(m : State[S, V]) -> State[S, V] {
-  m.map(fn { x => x })
+  m.map(fn(x) { x })
 }
 
 ///|
@@ -60,14 +60,14 @@ fn[S, V, W, X] map_associator(
   f : (V) -> W,
   g : (W) -> X,
 ) -> (State[S, X], State[S, X]) {
-  (m.map(f).map(g), m.map(fn { x => g(f(x)) }))
+  (m.map(f).map(g), m.map(fn(x) { g(f(x)) }))
 }
 
 ///|
 test "state_functor_laws" {
   let counter = State::new(10)
-  let add = fn { x => x + 2 }
-  let mul = fn { x => x * 2 }
+  let add = fn(x) { x + 2 }
+  let mul = fn(x) { x * 2 }
   let m1 = map_identity(counter)
   assert_true(run_state_eq((counter, m1), 0))
   let m2 = map_associator(counter, add, mul)

--- a/src/monad_laws_wbtest.mbt
+++ b/src/monad_laws_wbtest.mbt
@@ -1,29 +1,29 @@
 ///|
-fn left_identity[S, V](
+fn[S, V] left_identity(
   x : V,
-  f : (V) -> State[S, V]
+  f : (V) -> State[S, V],
 ) -> (State[S, V], State[S, V]) {
   (State::new(x).bind(f), f(x))
 }
 
 ///|
-fn right_identity[S, V](m : State[S, V]) -> (State[S, V], State[S, V]) {
+fn[S, V] right_identity(m : State[S, V]) -> (State[S, V], State[S, V]) {
   (m, m.bind(State::new))
 }
 
 ///|
-fn bind_associator[S, V, W, X](
+fn[S, V, W, X] bind_associator(
   m : State[S, V],
   f : (V) -> State[S, W],
-  g : (W) -> State[S, X]
+  g : (W) -> State[S, X],
 ) -> (State[S, X], State[S, X]) {
   (m.bind(f).bind(g), m.bind(fn { x => f(x).bind(g) }))
 }
 
 ///|
-fn run_state_eq[S : Eq + Show, V : Eq + Show](
+fn[S : Eq + Show, V : Eq + Show] run_state_eq(
   m : (State[S, V], State[S, V]),
-  state : S
+  state : S,
 ) -> Bool {
   let (v1, s1) = run_state(m.0, state)
   let (v2, s2) = run_state(m.1, state)
@@ -42,23 +42,23 @@ test "state_monad_laws" {
   }
 
   let m1 = left_identity(10, add)
-  assert_true!(run_state_eq(m1, 0))
+  assert_true(run_state_eq(m1, 0))
   let m2 = right_identity(counter)
-  assert_true!(run_state_eq(m2, 0))
+  assert_true(run_state_eq(m2, 0))
   let m3 = bind_associator(counter, add, mul)
-  assert_true!(run_state_eq(m3, 0))
+  assert_true(run_state_eq(m3, 0))
 }
 
 ///|
-fn map_identity[S, V](m : State[S, V]) -> State[S, V] {
+fn[S, V] map_identity(m : State[S, V]) -> State[S, V] {
   m.map(fn { x => x })
 }
 
 ///|
-fn map_associator[S, V, W, X](
+fn[S, V, W, X] map_associator(
   m : State[S, V],
   f : (V) -> W,
-  g : (W) -> X
+  g : (W) -> X,
 ) -> (State[S, X], State[S, X]) {
   (m.map(f).map(g), m.map(fn { x => g(f(x)) }))
 }
@@ -69,7 +69,7 @@ test "state_functor_laws" {
   let add = fn { x => x + 2 }
   let mul = fn { x => x * 2 }
   let m1 = map_identity(counter)
-  assert_true!(run_state_eq((counter, m1), 0))
+  assert_true(run_state_eq((counter, m1), 0))
   let m2 = map_associator(counter, add, mul)
-  assert_true!(run_state_eq(m2, 0))
+  assert_true(run_state_eq(m2, 0))
 }

--- a/src/src.mbti
+++ b/src/src.mbti
@@ -1,34 +1,25 @@
-package CAIMEOX/state/src
+// Generated using `moon info`, DON'T EDIT IT
+package "CAIMEOX/state/src"
 
 // Values
-fn bind[S, V, W](State[S, V], (V) -> State[S, W]) -> State[S, W]
+fn[S] get() -> State[S, S]
 
-fn eval_state[S, V](State[S, V], S) -> V
+fn[S] modify((S) -> S) -> State[S, Unit]
 
-fn exec_state[S, V](State[S, V], S) -> S
+fn[S] put(S) -> State[S, Unit]
 
-fn get[S]() -> State[S, S]
+fn[S, V] state((S) -> (V, S)) -> State[S, V]
 
-fn map[S, V, W](State[S, V], (V) -> W) -> State[S, W]
-
-fn modify[S]((S) -> S) -> State[S, Unit]
-
-fn put[S](S) -> State[S, Unit]
-
-fn run_state[S, V](State[S, V], S) -> (V, S)
-
-fn state[S, V]((S) -> (V, S)) -> State[S, V]
+// Errors
 
 // Types and methods
 type State[S, V]
-impl State {
-  bind[S, V, W](Self[S, V], (V) -> Self[S, W]) -> Self[S, W]
-  eval_state[S, V](Self[S, V], S) -> V
-  exec_state[S, V](Self[S, V], S) -> S
-  map[S, V, W](Self[S, V], (V) -> W) -> Self[S, W]
-  new[S, V](V) -> Self[S, V]
-  run_state[S, V](Self[S, V], S) -> (V, S)
-}
+fn[S, V, W] State::bind(Self[S, V], (V) -> Self[S, W]) -> Self[S, W]
+fn[S, V] State::eval_state(Self[S, V], S) -> V
+fn[S, V] State::exec_state(Self[S, V], S) -> S
+fn[S, V, W] State::map(Self[S, V], (V) -> W) -> Self[S, W]
+fn[S, V] State::new(V) -> Self[S, V]
+fn[S, V] State::run_state(Self[S, V], S) -> (V, S)
 
 // Type aliases
 

--- a/src/state.mbt
+++ b/src/state.mbt
@@ -9,7 +9,7 @@ struct State[S, V] {
 /// ```
 /// let state: State[List[Int], Int] = State::new(10)
 /// ```
-pub fn State::new[S, V](val : V) -> State[S, V] {
+pub fn[S, V] State::new(val : V) -> State[S, V] {
   { runState: fn { state => (val, state) } }
 }
 
@@ -19,7 +19,7 @@ pub fn State::new[S, V](val : V) -> State[S, V] {
 /// ```
 /// let state: State[Int, Int] = state(fn { x => (x + 1, x + 1) })
 /// ```
-pub fn state[S, V](f : (S) -> (V, S)) -> State[S, V] {
+pub fn[S, V] state(f : (S) -> (V, S)) -> State[S, V] {
   { runState: f }
 }
 
@@ -30,7 +30,7 @@ pub fn state[S, V](f : (S) -> (V, S)) -> State[S, V] {
 /// let state: State[Int, Int] = State::new(10)
 ///   |> bind(fn { _ => get() })
 /// ```
-pub fn get[S]() -> State[S, S] {
+pub fn[S] get() -> State[S, S] {
   { runState: fn { state => (state, state) } }
 }
 
@@ -41,7 +41,7 @@ pub fn get[S]() -> State[S, S] {
 /// let state: State[Int, Unit] = State::new(10)
 ///  |> bind(fn { _ => put(20) })
 /// ```
-pub fn put[S](new_state : S) -> State[S, Unit] {
+pub fn[S] put(new_state : S) -> State[S, Unit] {
   { runState: fn { _ => ((), new_state) } }
 }
 
@@ -52,7 +52,7 @@ pub fn put[S](new_state : S) -> State[S, Unit] {
 /// let state : State[Int, Int] = State::new(10)
 ///   |> map(fn { x => x + 1 })
 /// ```
-pub fn map[S, V, W](self : State[S, V], f : (V) -> W) -> State[S, W] {
+pub fn[S, V, W] map(self : State[S, V], f : (V) -> W) -> State[S, W] {
   {
     runState: fn(state : S) {
       let (val, new_state) = (self.runState)(state)
@@ -69,7 +69,7 @@ pub fn map[S, V, W](self : State[S, V], f : (V) -> W) -> State[S, W] {
 ///  |> bind(fn { _ => modify(fn { x => x + 1 }) })
 ///  |> bind(fn {_  => get()})
 /// ```
-pub fn modify[S](f : (S) -> S) -> State[S, Unit] {
+pub fn[S] modify(f : (S) -> S) -> State[S, Unit] {
   { runState: fn(state : S) { ((), f(state)) } }
 }
 
@@ -81,7 +81,7 @@ pub fn modify[S](f : (S) -> S) -> State[S, Unit] {
 ///  |> bind(fn { _ => put(20) })
 ///  |> bind(fn { _ => get() |> bind(fn { x => new(x + 1) }) })
 /// ```
-pub fn bind[S, V, W](self : State[S, V], f : (V) -> State[S, W]) -> State[S, W] {
+pub fn[S, V, W] bind(self : State[S, V], f : (V) -> State[S, W]) -> State[S, W] {
   {
     runState: fn(state : S) {
       let (val, new_state) = (self.runState)(state)
@@ -98,14 +98,14 @@ pub fn bind[S, V, W](self : State[S, V], f : (V) -> State[S, W]) -> State[S, W] 
 /// let state : State[Int, Int] = State::new(10)
 /// run_state(state, 0)
 /// ```
-pub fn run_state[S, V](self : State[S, V], state : S) -> (V, S) {
+pub fn[S, V] run_state(self : State[S, V], state : S) -> (V, S) {
   (self.runState)(state)
 }
 
 ///| Evaluate a state computation with the given initial state and return the final value, discarding the final state.
 /// 
 /// # Example
-pub fn eval_state[S, V](self : State[S, V], state : S) -> V {
+pub fn[S, V] eval_state(self : State[S, V], state : S) -> V {
   run_state(self, state).0
 }
 
@@ -116,6 +116,6 @@ pub fn eval_state[S, V](self : State[S, V], state : S) -> V {
 /// let state : State[Int, Unit] = State::new(10)
 ///  |> bind(fn { _ => put(20) })
 /// ```
-pub fn exec_state[S, V](self : State[S, V], state : S) -> S {
+pub fn[S, V] exec_state(self : State[S, V], state : S) -> S {
   run_state(self, state).1
 }

--- a/src/state.mbt
+++ b/src/state.mbt
@@ -7,17 +7,17 @@ struct State[S, V] {
 /// 
 /// # Example
 /// ```
-/// let state: State[List[Int], Int] = State::new(10)
+/// let _state: State[Int, Int] = State::new(10)
 /// ```
 pub fn[S, V] State::new(val : V) -> State[S, V] {
-  { runState: fn { state => (val, state) } }
+  { runState: fn(state) { (val, state) } }
 }
 
 ///| Embed a simple state action into the state monad.
 /// 
 /// # Example
 /// ```
-/// let state: State[Int, Int] = state(fn { x => (x + 1, x + 1) })
+/// let _state: State[Int, Int] = state(fn(x) { (x + 1, x + 1) })
 /// ```
 pub fn[S, V] state(f : (S) -> (V, S)) -> State[S, V] {
   { runState: f }
@@ -27,30 +27,27 @@ pub fn[S, V] state(f : (S) -> (V, S)) -> State[S, V] {
 /// 
 /// # Example
 /// ```
-/// let state: State[Int, Int] = State::new(10)
-///   |> bind(fn { _ => get() })
+/// let _state: State[Int, Int] = State::new(10).bind(fn(_) { get() })
 /// ```
 pub fn[S] get() -> State[S, S] {
-  { runState: fn { state => (state, state) } }
+  { runState: fn(state) { (state, state) } }
 }
 
 ///| Replace the state inside the monad.
 /// 
 /// # Example
 /// ```
-/// let state: State[Int, Unit] = State::new(10)
-///  |> bind(fn { _ => put(20) })
+/// let _state: State[Int, Unit] = State::new(10).bind(fn(_) { put(20) })
 /// ```
 pub fn[S] put(new_state : S) -> State[S, Unit] {
-  { runState: fn { _ => ((), new_state) } }
+  { runState: fn(_) { ((), new_state) } }
 }
 
 ///| Maps a value inside a state monad.
 /// 
 /// # Example
 /// ```
-/// let state : State[Int, Int] = State::new(10)
-///   |> map(fn { x => x + 1 })
+/// let _state : State[Int, Int] = State::new(10).map(fn(x) { x + 1 })
 /// ```
 pub fn[S, V, W] map(self : State[S, V], f : (V) -> W) -> State[S, W] {
   {
@@ -65,9 +62,9 @@ pub fn[S, V, W] map(self : State[S, V], f : (V) -> W) -> State[S, W] {
 /// 
 /// # Example
 /// ```
-/// let state : State[Int, Int] = State::new(0)
-///  |> bind(fn { _ => modify(fn { x => x + 1 }) })
-///  |> bind(fn {_  => get()})
+/// let _state : State[Int, Int] = State::new(0)
+///   .bind(fn(_) { modify(fn(x) { x + 1 }) })
+///   .bind(fn(_) { get() })
 /// ```
 pub fn[S] modify(f : (S) -> S) -> State[S, Unit] {
   { runState: fn(state : S) { ((), f(state)) } }
@@ -77,9 +74,9 @@ pub fn[S] modify(f : (S) -> S) -> State[S, Unit] {
 /// 
 /// # Example
 /// ```
-/// let state : State[Int, Int] = State::new(10)
-///  |> bind(fn { _ => put(20) })
-///  |> bind(fn { _ => get() |> bind(fn { x => new(x + 1) }) })
+/// let _state : State[Int, Int] = State::new(10)
+///   .bind(fn(_) { put(20) })
+///   .bind(fn(_) { get().bind(fn(x) { State::new(x + 1) }) })
 /// ```
 pub fn[S, V, W] bind(self : State[S, V], f : (V) -> State[S, W]) -> State[S, W] {
   {
@@ -96,7 +93,7 @@ pub fn[S, V, W] bind(self : State[S, V], f : (V) -> State[S, W]) -> State[S, W] 
 /// # Example
 /// ```
 /// let state : State[Int, Int] = State::new(10)
-/// run_state(state, 0)
+/// let _result = state.run_state(0)
 /// ```
 pub fn[S, V] run_state(self : State[S, V], state : S) -> (V, S) {
   (self.runState)(state)
@@ -106,16 +103,15 @@ pub fn[S, V] run_state(self : State[S, V], state : S) -> (V, S) {
 /// 
 /// # Example
 pub fn[S, V] eval_state(self : State[S, V], state : S) -> V {
-  run_state(self, state).0
+  self.run_state(state).0
 }
 
 ///| Evaluate a state computation with the given initial state and return the final state, discarding the final value.
 /// 
 /// # Example
 /// ```
-/// let state : State[Int, Unit] = State::new(10)
-///  |> bind(fn { _ => put(20) })
+/// let _state : State[Int, Unit] = State::new(10).bind(fn(_) { put(20) })
 /// ```
 pub fn[S, V] exec_state(self : State[S, V], state : S) -> S {
-  run_state(self, state).1
+  self.run_state(state).1
 }

--- a/src/state_wbtest.mbt
+++ b/src/state_wbtest.mbt
@@ -1,31 +1,31 @@
 ///|
 test "new" {
   let state : State[Int, Int] = State::new(10)
-  assert_eq!(run_state(state, 0), (10, 0))
+  assert_eq(run_state(state, 0), (10, 0))
 }
 
 ///|
 test "state" {
   let state : State[Int, Int] = state(fn { x => (x + 1, x + 1) })
-  assert_eq!(run_state(state, 0), (1, 1))
+  assert_eq(run_state(state, 0), (1, 1))
 }
 
 ///|
 test "get" {
   let state : State[Int, Int] = State::new(10) |> bind(fn { _ => get() })
-  assert_eq!(run_state(state, 20), (20, 20))
+  assert_eq(run_state(state, 20), (20, 20))
 }
 
 ///|
 test "put" {
   let state : State[Int, Unit] = State::new(10) |> bind(fn { _ => put(20) })
-  assert_eq!(run_state(state, 0), ((), 20))
+  assert_eq(run_state(state, 0), ((), 20))
 }
 
 ///|
 test "map" {
   let state : State[Int, Int] = State::new(10) |> map(fn { x => x + 1 })
-  assert_eq!(run_state(state, 0), (11, 0))
+  assert_eq(run_state(state, 0), (11, 0))
 }
 
 ///|
@@ -33,7 +33,7 @@ test "modify" {
   let state : State[Int, Int] = State::new(0)
     |> bind(fn { _ => modify(fn { x => x + 1 }) })
     |> bind(fn { _ => get() })
-  assert_eq!(run_state(state, 0), (1, 1))
+  assert_eq(run_state(state, 0), (1, 1))
 }
 
 ///|
@@ -41,13 +41,13 @@ test "bind" {
   let state : State[Int, Int] = State::new(10)
     |> bind(fn { _ => put(20) })
     |> bind(fn { _ => get() |> bind(fn { x => State::new(x + 1) }) })
-  assert_eq!(run_state(state, 0), (21, 20))
+  assert_eq(run_state(state, 0), (21, 20))
 }
 
 ///|
 test "run_state" {
   let state : State[Int, Int] = State::new(10)
-  assert_eq!(run_state(state, 0), (10, 0))
+  assert_eq(run_state(state, 0), (10, 0))
 }
 
 ///|
@@ -55,17 +55,17 @@ test "eval_state" {
   let state : State[Int, Int] = State::new(10)
     |> bind(fn { _ => put(20) })
     |> bind(fn { _ => get() |> bind(fn { x => State::new(x + 1) }) })
-  assert_eq!(eval_state(state, 0), 21)
+  assert_eq(eval_state(state, 0), 21)
 }
 
 ///|
 test "exec_state" {
   let state : State[Int, Unit] = State::new(10) |> bind(fn { _ => put(20) })
-  assert_eq!(exec_state(state, 0), 20)
+  assert_eq(exec_state(state, 0), 20)
 }
 
 ///|
-typealias List[T] = @immut/list.T[T]
+typealias @immut/list.T as List
 
 ///|
 test "state_stack" {
@@ -97,25 +97,25 @@ test "state_stack" {
     |> bind(fn { _ => push(5) })
     |> bind(fn { _ => plus() })
     |> bind(fn { _ => mult() })
-  assert_eq!(run_state(prog, Nil), (16, Cons(16, Nil)))
+  assert_eq(run_state(prog, Nil), (16, Cons(16, Nil)))
   let prog2 : State[List[Int], String] = State::new(10)
     |> bind(fn { x => push(3 + x) })
     |> bind(fn { _ => push(5) })
     |> bind(fn { _ => mult() })
     |> map(fn { x => x.to_string() })
-  assert_eq!(eval_state(prog2, Nil), "65")
+  assert_eq(eval_state(prog2, Nil), "65")
   let prog3 = push(2) |> bind(fn { _ => push(3) }) |> bind(fn { _ => get() })
-  assert_eq!(eval_state(prog3, Nil), Cons(3, Cons(2, Nil)))
+  assert_eq(eval_state(prog3, Nil), Cons(3, Cons(2, Nil)))
   let prog4 = State::new(0)
     |> bind(fn { _ => put(123) })
     |> bind(fn { _ => get() })
-  assert_eq!(run_state(prog4, 0), (123, 123))
+  assert_eq(run_state(prog4, 0), (123, 123))
   let prog5 : State[List[Int], Int] = State::new(5)
-  assert_eq!(eval_state(prog5, Nil), 5)
+  assert_eq(eval_state(prog5, Nil), 5)
   let prog6 : State[List[Int], Int] = push(2)
     |> bind(fn { _ => modify(fn { x => Cons(100, x) }) })
     |> bind(fn { _ => mult() })
-  assert_eq!(run_state(prog6, Nil), (200, Cons(200, Nil)))
+  assert_eq(run_state(prog6, Nil), (200, Cons(200, Nil)))
 }
 
 ///|
@@ -125,6 +125,6 @@ test "tick_state" {
   }
 
   for i = 0; i < 100; i = i + 1 {
-    assert_eq!(exec_state(tick(), i), i + 1)
+    assert_eq(exec_state(tick(), i), i + 1)
   }
 }

--- a/src/state_wbtest.mbt
+++ b/src/state_wbtest.mbt
@@ -1,130 +1,127 @@
 ///|
 test "new" {
   let state : State[Int, Int] = State::new(10)
-  assert_eq(run_state(state, 0), (10, 0))
+  assert_eq(state.run_state(0), (10, 0))
 }
 
 ///|
 test "state" {
-  let state : State[Int, Int] = state(fn { x => (x + 1, x + 1) })
-  assert_eq(run_state(state, 0), (1, 1))
+  let state : State[Int, Int] = state(fn(x) { (x + 1, x + 1) })
+  assert_eq(state.run_state(0), (1, 1))
 }
 
 ///|
 test "get" {
-  let state : State[Int, Int] = State::new(10) |> bind(fn { _ => get() })
-  assert_eq(run_state(state, 20), (20, 20))
+  let state : State[Int, Int] = State::new(10).bind(fn(_) { get() })
+  assert_eq(state.run_state(20), (20, 20))
 }
 
 ///|
 test "put" {
-  let state : State[Int, Unit] = State::new(10) |> bind(fn { _ => put(20) })
-  assert_eq(run_state(state, 0), ((), 20))
+  let state : State[Int, Unit] = State::new(10).bind(fn(_) { put(20) })
+  assert_eq(state.run_state(0), ((), 20))
 }
 
 ///|
 test "map" {
-  let state : State[Int, Int] = State::new(10) |> map(fn { x => x + 1 })
-  assert_eq(run_state(state, 0), (11, 0))
+  let state : State[Int, Int] = State::new(10).map(fn(x) { x + 1 })
+  assert_eq(state.run_state(0), (11, 0))
 }
 
 ///|
 test "modify" {
   let state : State[Int, Int] = State::new(0)
-    |> bind(fn { _ => modify(fn { x => x + 1 }) })
-    |> bind(fn { _ => get() })
-  assert_eq(run_state(state, 0), (1, 1))
+    .bind(fn(_) { modify(fn(x) { x + 1 }) })
+    .bind(fn(_) { get() })
+  assert_eq(state.run_state(0), (1, 1))
 }
 
 ///|
 test "bind" {
   let state : State[Int, Int] = State::new(10)
-    |> bind(fn { _ => put(20) })
-    |> bind(fn { _ => get() |> bind(fn { x => State::new(x + 1) }) })
-  assert_eq(run_state(state, 0), (21, 20))
+    .bind(fn(_) { put(20) })
+    .bind(fn(_) { get().bind(fn(x) { State::new(x + 1) }) })
+  assert_eq(state.run_state(0), (21, 20))
 }
 
 ///|
 test "run_state" {
   let state : State[Int, Int] = State::new(10)
-  assert_eq(run_state(state, 0), (10, 0))
+  assert_eq(state.run_state(0), (10, 0))
 }
 
 ///|
 test "eval_state" {
   let state : State[Int, Int] = State::new(10)
-    |> bind(fn { _ => put(20) })
-    |> bind(fn { _ => get() |> bind(fn { x => State::new(x + 1) }) })
-  assert_eq(eval_state(state, 0), 21)
+    .bind(fn(_) { put(20) })
+    .bind(fn(_) { get().bind(fn(x) { State::new(x + 1) }) })
+  assert_eq(state.eval_state(0), 21)
 }
 
 ///|
 test "exec_state" {
-  let state : State[Int, Unit] = State::new(10) |> bind(fn { _ => put(20) })
-  assert_eq(exec_state(state, 0), 20)
+  let state : State[Int, Unit] = State::new(10).bind(fn(_) { put(20) })
+  assert_eq(state.exec_state(0), 20)
 }
 
 ///|
-typealias @immut/list.T as List
 
 ///|
 test "state_stack" {
-  fn push(n : Int) -> State[List[Int], Int] {
-    { runState: fn(ns : List[Int]) { (n, Cons(n, ns)) } }
+  fn push(n : Int) -> State[@array.View[Int], Int] {
+    { runState: fn(ns : @array.View[Int]) { (n, [n, ..ns]) } }
   }
 
-  fn pop() -> State[List[Int], Int] {
+  fn pop() -> State[@array.View[Int], Int] {
     {
-      runState: fn(ns : List[Int]) {
+      runState: fn(ns : @array.View[Int]) {
         match ns {
-          Cons(n, ns) => (n, ns)
-          Nil => abort("empty stack")
+          [] => abort("empty stack")
+          [n, .. ns] => (n, ns)
         }
       },
     }
   }
 
-  fn plus() -> State[List[Int], Int] {
-    bind(pop(), fn(n1) { bind(pop(), fn(n2) { push(n1 + n2) }) })
+  fn plus() -> State[@array.View[Int], Int] {
+    pop().bind(fn(n1) { pop().bind(fn(n2) { push(n1 + n2) }) })
   }
 
-  fn mult() -> State[List[Int], Int] {
-    bind(pop(), fn(n1) { bind(pop(), fn(n2) { push(n1 * n2) }) })
+  fn mult() -> State[@array.View[Int], Int] {
+    pop().bind(fn(n1) { pop().bind(fn(n2) { push(n1 * n2) }) })
   }
 
-  let prog : State[List[Int], Int] = push(2)
-    |> bind(fn { _ => push(3) })
-    |> bind(fn { _ => push(5) })
-    |> bind(fn { _ => plus() })
-    |> bind(fn { _ => mult() })
-  assert_eq(run_state(prog, Nil), (16, Cons(16, Nil)))
-  let prog2 : State[List[Int], String] = State::new(10)
-    |> bind(fn { x => push(3 + x) })
-    |> bind(fn { _ => push(5) })
-    |> bind(fn { _ => mult() })
-    |> map(fn { x => x.to_string() })
-  assert_eq(eval_state(prog2, Nil), "65")
-  let prog3 = push(2) |> bind(fn { _ => push(3) }) |> bind(fn { _ => get() })
-  assert_eq(eval_state(prog3, Nil), Cons(3, Cons(2, Nil)))
-  let prog4 = State::new(0)
-    |> bind(fn { _ => put(123) })
-    |> bind(fn { _ => get() })
-  assert_eq(run_state(prog4, 0), (123, 123))
-  let prog5 : State[List[Int], Int] = State::new(5)
-  assert_eq(eval_state(prog5, Nil), 5)
-  let prog6 : State[List[Int], Int] = push(2)
-    |> bind(fn { _ => modify(fn { x => Cons(100, x) }) })
-    |> bind(fn { _ => mult() })
-  assert_eq(run_state(prog6, Nil), (200, Cons(200, Nil)))
+  let prog : State[@array.View[Int], Int] = push(2)
+    .bind(fn(_) { push(3) })
+    .bind(fn(_) { push(5) })
+    .bind(fn(_) { plus() })
+    .bind(fn(_) { mult() })
+  assert_eq(prog.run_state([]), (16, [16]))
+  let prog2 : State[@array.View[Int], String] = State::new(10)
+    .bind(fn(x) { push(3 + x) })
+    .bind(fn(_) { push(5) })
+    .bind(fn(_) { mult() })
+    .map(fn(x) { x.to_string() })
+  assert_eq(prog2.eval_state([]), "65")
+  let prog3 = push(2).bind(fn(_) { push(3) }).bind(fn(_) { get() })
+  assert_eq(prog3.eval_state([]), [3, 2])
+  let prog4 = State::new(0).bind(fn(_) { put(123) }).bind(fn(_) { get() })
+  assert_eq(prog4.run_state(0), (123, 123))
+  let prog5 : State[@array.View[Int], Int] = State::new(5)
+  assert_eq(prog5.eval_state([]), 5)
+  let prog6 : State[@array.View[Int], Int] = push(2)
+    .bind(fn(_) { modify(fn(x) { [100, ..x] }) })
+    .bind(fn(_) { mult() })
+  assert_eq(prog6.run_state([]), (200, [200]))
 }
 
 ///|
 test "tick_state" {
   fn tick() -> State[Int, Int] {
-    get().bind(fn { x => put(x + 1).bind(fn { _ => State::new(x) }) })
+    get().bind(fn(x) { put(x + 1).bind(fn(_) { State::new(x) }) })
   }
 
   for i = 0; i < 100; i = i + 1 {
-    assert_eq(exec_state(tick(), i), i + 1)
+    assert_eq(tick().exec_state(i), i + 1)
   }
 }


### PR DESCRIPTION
> [!NOTE]
> This PR was made by an LLM agent.

- Updated deprecated anonymous matrix function syntax (fn { .. } -> fn(..) { .. })
- Fixed deprecated method call syntax (f(..) -> x.f(..) or T::f(..))
- Removed unused trait bounds in function signatures  
- Updated deprecated @immut/list.T usage to modern API with @array.View
- Fixed documentation examples to prevent unused variable warnings
- Ensured all code compiles without warnings and passes tests

All 23 tests continue to pass after these changes.